### PR TITLE
DIRKRB-408

### DIFF
--- a/benchmark/src/main/java/org/apache/kerby/benchmark/JsonBackendBenchmark.java
+++ b/benchmark/src/main/java/org/apache/kerby/benchmark/JsonBackendBenchmark.java
@@ -84,7 +84,10 @@ public class JsonBackendBenchmark {
         }
 
         if (jsonBackendFile.exists()) {
-            jsonBackendFile.delete();
+            boolean delete = jsonBackendFile.delete();
+            if (!delete) {
+                throw new RuntimeException("File delete error!");
+            }
         }
     }
 }

--- a/benchmark/src/main/java/org/apache/kerby/benchmark/KrbCodecBenchmark.java
+++ b/benchmark/src/main/java/org/apache/kerby/benchmark/KrbCodecBenchmark.java
@@ -46,6 +46,7 @@ public class KrbCodecBenchmark {
             byte[] bytes = new byte[is.available()];
             is.read(bytes);
             apreqToken = ByteBuffer.wrap(bytes);
+            is.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/benchmark/src/main/java/org/apache/kerby/benchmark/KrbCodecBenchmark.java
+++ b/benchmark/src/main/java/org/apache/kerby/benchmark/KrbCodecBenchmark.java
@@ -41,12 +41,10 @@ public class KrbCodecBenchmark {
     private static ByteBuffer apreqToken;
 
     static {
-        InputStream is = KrbCodecBenchmark.class.getResourceAsStream("/apreq.token");
-        try {
+        try (InputStream is = KrbCodecBenchmark.class.getResourceAsStream("/apreq.token");) {
             byte[] bytes = new byte[is.available()];
             is.read(bytes);
             apreqToken = ByteBuffer.wrap(bytes);
-            is.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/kerby-backend/json-backend/src/main/java/org/apache/kerby/kerberos/kdc/identitybackend/JsonIdentityBackend.java
+++ b/kerby-backend/json-backend/src/main/java/org/apache/kerby/kerberos/kdc/identitybackend/JsonIdentityBackend.java
@@ -266,8 +266,14 @@ public class JsonIdentityBackend extends AbstractIdentityBackend {
             File newJsonKdbFile = File.createTempFile("kerby-kdb",
                     ".json", jsonKdbFile.getParentFile());
             IOUtil.writeFile(newJsonContent, newJsonKdbFile);
-            jsonKdbFile.delete();
-            newJsonKdbFile.renameTo(jsonKdbFile);
+            boolean delete = jsonKdbFile.delete();
+            if (!delete) {
+                throw new RuntimeException("File delete error!");
+            }
+            boolean rename = newJsonKdbFile.renameTo(jsonKdbFile);
+            if (!rename) {
+                throw new RuntimeException("File rename error!");
+            }
             kdbFileUpdateTime = jsonKdbFile.lastModified();
         } catch (IOException e) {
             LOG.error("Error occurred while writing identities to file: " + jsonKdbFile);

--- a/kerby-kerb/integration-test/src/main/java/org/apache/kerby/kerberos/kerb/integration/test/jaas/TokenAuthLoginModule.java
+++ b/kerby-kerb/integration-test/src/main/java/org/apache/kerby/kerberos/kerb/integration/test/jaas/TokenAuthLoginModule.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.Iterator;
@@ -155,7 +156,11 @@ public class TokenAuthLoginModule implements LoginModule {
             throw new LoginException("Subject is Readonly");
         }
 
-        subject.getPrincipals().remove(princName);
+        for (Principal principal: subject.getPrincipals()) {
+            if (principal.getName().equals(princName)) {
+                subject.getPrincipals().remove(principal);
+            }
+        }
         // Let us remove all Kerberos credentials stored in the Subject
         Iterator<Object> it = subject.getPrivateCredentials().iterator();
         while (it.hasNext()) {
@@ -256,7 +261,9 @@ public class TokenAuthLoginModule implements LoginModule {
             e.printStackTrace();
         }
         try {
-            krbClient.storeTicket(tgtTicket, cCache);
+            if (krbClient != null) {
+                krbClient.storeTicket(tgtTicket, cCache);
+            }
         } catch (KrbException e) {
             e.printStackTrace();
         }
@@ -277,7 +284,10 @@ public class TokenAuthLoginModule implements LoginModule {
 
     private void cleanup() {
         if (cCache != null && cCache.exists()) {
-            cCache.delete();
+            boolean delete = cCache.delete();
+            if (!delete) {
+                throw new RuntimeException("File delete error!");
+            }
         }
     }
 

--- a/kerby-kerb/kerb-util/src/main/java/org/apache/kerby/kerberos/kerb/ccache/CredentialCache.java
+++ b/kerby-kerb/kerb-util/src/main/java/org/apache/kerby/kerberos/kerb/ccache/CredentialCache.java
@@ -81,9 +81,9 @@ public class CredentialCache implements KrbCredentialCache {
 
     @Override
     public void store(File ccacheFile) throws IOException {
-        OutputStream outputStream = new FileOutputStream(ccacheFile);
-        store(outputStream);
-        outputStream.close();
+        try (OutputStream outputStream = new FileOutputStream(ccacheFile)) {
+            store(outputStream);
+        }
     }
 
     @Override
@@ -190,9 +190,9 @@ public class CredentialCache implements KrbCredentialCache {
                     + ccacheFile.getAbsolutePath());
         }
 
-        InputStream inputStream = new FileInputStream(ccacheFile);
-        load(inputStream);
-        inputStream.close();
+        try (InputStream inputStream = new FileInputStream(ccacheFile)) {
+            load(inputStream);
+        }
     }
 
     @Override

--- a/kerby-kerb/kerb-util/src/main/java/org/apache/kerby/kerberos/kerb/keytab/Keytab.java
+++ b/kerby-kerb/kerb-util/src/main/java/org/apache/kerby/kerberos/kerb/keytab/Keytab.java
@@ -140,9 +140,9 @@ public final class Keytab implements KrbKeytab {
             throw new IllegalArgumentException("Invalid keytab file: " + keytabFile.getAbsolutePath());
         }
 
-        InputStream is = new FileInputStream(keytabFile);
-        load(is);
-        is.close();
+        try (InputStream is = new FileInputStream(keytabFile)) {
+            load(is);
+        }
     }
 
     @Override
@@ -201,9 +201,9 @@ public final class Keytab implements KrbKeytab {
 
     @Override
     public void store(File keytabFile) throws IOException {
-        OutputStream outputStream = new FileOutputStream(keytabFile);
-        store(outputStream);
-        outputStream.close();
+        try (OutputStream outputStream = new FileOutputStream(keytabFile)) {
+            store(outputStream);
+        }
     }
 
     @Override

--- a/kerby-kerb/kerb-util/src/main/java/org/apache/kerby/kerberos/kerb/keytab/KeytabInputStream.java
+++ b/kerby-kerb/kerb-util/src/main/java/org/apache/kerby/kerberos/kerb/keytab/KeytabInputStream.java
@@ -77,7 +77,7 @@ public class KeytabInputStream extends KrbInputStream {
     public String readCountedString() throws IOException {
         byte[] countedOctets = readCountedOctets();
         // ASCII
-        return new String(countedOctets);
+        return new String(countedOctets, "ASCII");
     }
 
     @Override

--- a/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/AuthUtil.java
+++ b/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/AuthUtil.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 public class AuthUtil {
 
-    public static boolean enableDebug = true;
+    public static final boolean ENABLE_DEBUG = true;
 
     private static String getKrb5LoginModuleName() {
         return System.getProperty("java.vendor").contains("IBM")
@@ -101,7 +101,7 @@ public class AuthUtil {
             options.put("refreshKrb5Config", "true");
             options.put("isInitiator", "true");
             options.put("ticketCache", clientCredentialFile.getAbsolutePath());
-            options.put("debug", String.valueOf(enableDebug));
+            options.put("debug", String.valueOf(ENABLE_DEBUG));
 
             return new AppConfigurationEntry[]{
                 new AppConfigurationEntry(getKrb5LoginModuleName(),
@@ -130,7 +130,7 @@ public class AuthUtil {
             options.put("renewTGT", "false");
             options.put("refreshKrb5Config", "true");
             options.put("isInitiator", "true");
-            options.put("debug", String.valueOf(enableDebug));
+            options.put("debug", String.valueOf(ENABLE_DEBUG));
 
             return new AppConfigurationEntry[]{
                 new AppConfigurationEntry(getKrb5LoginModuleName(),

--- a/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/Krb5Conf.java
+++ b/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/Krb5Conf.java
@@ -74,7 +74,10 @@ public class Krb5Conf {
 
         File confFile = new File(confDir, KRB5_CONF_FILE);
         if (confFile.exists()) {
-            confFile.delete();
+            boolean delete = confFile.delete();
+            if (!delete) {
+                throw new RuntimeException("File delete error!");
+            }
         }
         IOUtil.writeFile(content, confFile);
 

--- a/kerby-util/src/main/java/org/apache/kerby/util/Util.java
+++ b/kerby-util/src/main/java/org/apache/kerby/util/Util.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.Charset;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.Certificate;
@@ -389,7 +390,7 @@ public class Util {
 
     public static void main(String[] args) throws Exception {
         String s = "line1\n\rline2\n\rline3";
-        ByteArrayInputStream in = new ByteArrayInputStream(s.getBytes());
+        ByteArrayInputStream in = new ByteArrayInputStream(s.getBytes(Charset.forName("UTF-8")));
         ByteArrayReadLine readLine = new ByteArrayReadLine(in);
         String line = readLine.next();
         while (line != null) {


### PR DESCRIPTION
Fix most bugs in the 5 modules in Description. However, there are 2 remaining bugs:

```
Unused field: org.apache.kerby.benchmark.generated.JsonBackendBenchmark_jmhType_B1.p000
```

In fact, there are 2304 of this same kind of bugs.

`new org.apache.kerby.kerberos.kerb.integration.test.Transport$Message(String, byte[]) may expose internal representation by storing an externally mutable object into Transport$Message.body`

I have tried `this.body = body.clone()`, however, it makes an error when test.
