### PR TITLE
DIRKRB-553

### DIFF
--- a/kerby-backend/json-backend/pom.xml
+++ b/kerby-backend/json-backend/pom.xml
@@ -48,5 +48,11 @@
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kerby-backend/ldap-backend/pom.xml
+++ b/kerby-backend/ldap-backend/pom.xml
@@ -88,5 +88,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kerby-backend/mavibot-backend/pom.xml
+++ b/kerby-backend/mavibot-backend/pom.xml
@@ -58,5 +58,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kerby-common/kerby-config/pom.xml
+++ b/kerby-common/kerby-config/pom.xml
@@ -34,8 +34,9 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
    </dependency>
   </dependencies>
 </project>

--- a/kerby-kerb/integration-test/pom.xml
+++ b/kerby-kerb/integration-test/pom.xml
@@ -49,5 +49,11 @@
       <artifactId>token-provider</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kerby-kerb/kerb-client/pom.xml
+++ b/kerby-kerb/kerb-client/pom.xml
@@ -46,5 +46,11 @@
       <artifactId>kerb-util</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kerby-kerb/kerb-kdc-test/pom.xml
+++ b/kerby-kerb/kerb-kdc-test/pom.xml
@@ -57,6 +57,12 @@
       <artifactId>kerb-client</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -73,5 +79,5 @@
         </executions>
       </plugin>
     </plugins>
-  </build>  
+  </build>
 </project>

--- a/kerby-kerb/kerb-server/pom.xml
+++ b/kerby-kerb/kerb-server/pom.xml
@@ -37,5 +37,11 @@
       <artifactId>kerb-identity</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kerby-pkix/pom.xml
+++ b/kerby-pkix/pom.xml
@@ -59,6 +59,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Remove `slf4j-log4j12` dependency from `kerby-config` to enable the applications to configure their binding.
