### PR TITLE
DIRKRB-748

### DIFF
--- a/kerby-kerb/kerb-admin/src/main/java/org/apache/kerby/kerberos/kerb/admin/Krb5Conf.java
+++ b/kerby-kerb/kerb-admin/src/main/java/org/apache/kerby/kerberos/kerb/admin/Krb5Conf.java
@@ -57,6 +57,7 @@ public class Krb5Conf {
         String content = templateContent;
 
         content = content.replaceAll("_REALM_", "" + kdcConfig.getKdcRealm());
+        content = content.replaceAll("_KDC_HOST_", "" + kdcConfig.getKdcHost());
 
         int kdcPort = kdcConfig.allowUdp() ? kdcConfig.getKdcUdpPort()
                 : kdcConfig.getKdcTcpPort();

--- a/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/Krb5Conf.java
+++ b/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/Krb5Conf.java
@@ -57,6 +57,7 @@ public class Krb5Conf {
         String content = templateContent;
 
         content = content.replaceAll("_REALM_", "" + kdcConfig.getKdcRealm());
+        content = content.replaceAll("_KDC_HOST_", "" + kdcConfig.getKdcHost());
 
         int kdcPort = kdcConfig.allowUdp() ? kdcConfig.getKdcUdpPort()
                 : kdcConfig.getKdcTcpPort();

--- a/kerby-tool/kdc-tool/src/main/resources/krb5.conf
+++ b/kerby-tool/kdc-tool/src/main/resources/krb5.conf
@@ -25,5 +25,5 @@
 
 [realms]
     _REALM_ = {
-        kdc = localhost:_KDC_PORT_
+        kdc = _KDC_HOST_:_KDC_PORT_
     }

--- a/kerby-tool/kdc-tool/src/main/resources/krb5_udp.conf
+++ b/kerby-tool/kdc-tool/src/main/resources/krb5_udp.conf
@@ -25,5 +25,5 @@
 
 [realms]
     _REALM_ = {
-        kdc = localhost:_KDC_PORT_
+        kdc = _KDC_HOST_:_KDC_PORT_
     }


### PR DESCRIPTION
KerbyAdminServer and RemoteAdminClientTool generate a krb5.conf file in conf dir. However, the KDC host in the template file is always localhost. When the RemoteAdminClientTool is used remotely, the KDC host needs to use the real KDC host instead of localhost.