### PR TITLE
search subtree to be able to use identities provisioned by other tool…

### DIFF
--- a/kerby-backend/ldap-backend/src/main/java/org/apache/kerby/kerberos/kdc/identitybackend/LdapIdentityBackend.java
+++ b/kerby-backend/ldap-backend/src/main/java/org/apache/kerby/kerberos/kdc/identitybackend/LdapIdentityBackend.java
@@ -267,8 +267,6 @@ public class LdapIdentityBackend extends AbstractIdentityBackend {
             entry.add("krb5KDCFlags", "" + identity.getKdcFlags());
             entry.add(KerberosAttribute.KRB5_ACCOUNT_DISABLED_AT, ""
                     + identity.isDisabled());
-            entry.add("createTimestamp",
-                    toGeneralizedTime(identity.getCreatedTime()));
             entry.add(KerberosAttribute.KRB5_ACCOUNT_LOCKEDOUT_AT, ""
                     + identity.isLocked());
             entry.add(KerberosAttribute.KRB5_ACCOUNT_EXPIRATION_TIME_AT,

--- a/kerby-backend/ldap-backend/src/main/java/org/apache/kerby/kerberos/kdc/identitybackend/LdapIdentityBackend.java
+++ b/kerby-backend/ldap-backend/src/main/java/org/apache/kerby/kerberos/kdc/identitybackend/LdapIdentityBackend.java
@@ -257,6 +257,7 @@ public class LdapIdentityBackend extends AbstractIdentityBackend {
             entry.setDn(dn);
             entry.add("objectClass", "top", "person", "inetOrgPerson",
                     "krb5principal", "krb5kdcentry");
+            entry.add("uid", names[0]);
             entry.add("cn", names[0]);
             entry.add("sn", names[0]);
             entry.add(KerberosAttribute.KRB5_KEY_AT, keysInfo.getKeys());


### PR DESCRIPTION
…s into child organizational unit and be more specific according to search class (use krb5principal)

Two changes are done:
1. the LDAP class used can be more specific to allow using LDAP search index which might be set to krb5principal
2. If there are many identities then they are often not manually provisioned by kerby tools; the better organize them subtrees could be used; therefore kerby should always search subtrees instead of only using one level