### PR TITLE
Fix checks for ibm security classes to work with recent IBM Semeru JDKs

### DIFF
--- a/has-project/has-common/src/main/java/org/apache/kerby/has/common/util/HasJaasLoginUtil.java
+++ b/has-project/has-common/src/main/java/org/apache/kerby/has/common/util/HasJaasLoginUtil.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.kerby.has.common.util.PlatformName.IBM_JAVA;
+
 /**
  * JAAS utilities for Has login.
  */
@@ -40,7 +42,7 @@ public class HasJaasLoginUtil {
     public static final boolean ENABLE_DEBUG = true;
 
     private static String getKrb5LoginModuleName() {
-        return System.getProperty("java.vendor").contains("IBM")
+        return IBM_JAVA
             ? "com.ibm.security.auth.module.Krb5LoginModule"
             : "org.apache.kerby.has.client.HasLoginModule";
     }

--- a/has-project/has-common/src/main/java/org/apache/kerby/has/common/util/PlatformName.java
+++ b/has-project/has-common/src/main/java/org/apache/kerby/has/common/util/PlatformName.java
@@ -49,9 +49,28 @@ public class PlatformName {
 
   /**
    * A public static variable to indicate the current java vendor is
-   * IBM java or not.
+   * IBM and the type is Java Technology Edition which provides its
+   * own implementations of many security packages and Cipher suites.
+   * Note that these are not provided in Semeru runtimes:
+   * See https://developer.ibm.com/languages/java/semeru-runtimes/
+   * The class used is present in any supported IBM JTE Runtimes.
    */
-  public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM");
+  public static final boolean IBM_JAVA = shouldUseIbmSecurity();
+
+  private static boolean shouldUseIbmSecurity() {
+    if (!JAVA_VENDOR_NAME.contains("IBM")) {
+      return false;
+    }
+
+    try {
+      Class.forName("com.ibm.security.auth.module.JAASLoginModule",
+        false,
+        PlatformName.class.getClassLoader());
+      return true;
+    } catch (Exception ignored) { }
+
+    return false;
+  }
 
   public static void main(String[] args) {
     System.out.println(PLATFORM_NAME);

--- a/kerby-common/kerby-util/src/main/java/org/apache/kerby/util/SysUtil.java
+++ b/kerby-common/kerby-util/src/main/java/org/apache/kerby/util/SysUtil.java
@@ -32,4 +32,29 @@ public final class SysUtil {
         return new File(tmpDir);
     }
 
+  /**
+   * A public static variable to indicate the current java vendor is
+   * IBM and the type is Java Technology Edition which provides its
+   * own implementations of many security packages and Cipher suites.
+   * Note that these are not provided in Semeru runtimes:
+   * See https://developer.ibm.com/languages/java/semeru-runtimes/
+   * The class used is present in any supported IBM JTE Runtimes.
+   */
+  public static final boolean IBM_JAVA = shouldUseIbmSecurity();
+
+  private static boolean shouldUseIbmSecurity() {
+    if (!System.getProperty("java.vendor").contains("IBM")) {
+      return false;
+    }
+
+    try {
+      Class.forName("com.ibm.security.auth.module.JAASLoginModule",
+        false,
+        SysUtil.class.getClassLoader());
+      return true;
+    } catch (Exception ignored) { }
+
+    return false;
+  }
+
 }

--- a/kerby-kerb/kerb-admin/src/main/java/org/apache/kerby/kerberos/kerb/admin/AuthUtil.java
+++ b/kerby-kerb/kerb-admin/src/main/java/org/apache/kerby/kerberos/kerb/admin/AuthUtil.java
@@ -26,6 +26,9 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+
+import static org.apache.kerby.util.SysUtil.IBM_JAVA;
+
 import java.io.File;
 import java.security.Principal;
 import java.util.HashMap;
@@ -38,7 +41,7 @@ public class AuthUtil {
     public static final boolean ENABLE_DEBUG = false;
 
     private static String getKrb5LoginModuleName() {
-        return System.getProperty("java.vendor").contains("IBM")
+        return IBM_JAVA
             ? "com.ibm.security.auth.module.Krb5LoginModule"
             : "com.sun.security.auth.module.Krb5LoginModule";
     }

--- a/kerby-kerb/kerb-simplekdc/src/main/java/org/apache/kerby/kerberos/kerb/client/JaasKrbUtil.java
+++ b/kerby-kerb/kerb-simplekdc/src/main/java/org/apache/kerby/kerberos/kerb/client/JaasKrbUtil.java
@@ -29,6 +29,9 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+
+import static org.apache.kerby.util.SysUtil.IBM_JAVA;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.Principal;
@@ -106,7 +109,7 @@ public final class JaasKrbUtil {
     }
 
     private static String getKrb5LoginModuleName() {
-        return System.getProperty("java.vendor").contains("IBM")
+        return IBM_JAVA
                 ? "com.ibm.security.auth.module.Krb5LoginModule"
                 : "com.sun.security.auth.module.Krb5LoginModule";
     }

--- a/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/AuthUtil.java
+++ b/kerby-tool/kdc-tool/src/main/java/org/apache/kerby/kerberos/tool/kadmin/AuthUtil.java
@@ -25,6 +25,9 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+
+import static org.apache.kerby.util.SysUtil.IBM_JAVA;
+
 import java.io.File;
 import java.security.Principal;
 import java.util.HashMap;
@@ -37,7 +40,7 @@ public class AuthUtil {
     public static final boolean ENABLE_DEBUG = true;
 
     private static String getKrb5LoginModuleName() {
-        return System.getProperty("java.vendor").contains("IBM")
+        return IBM_JAVA
             ? "com.ibm.security.auth.module.Krb5LoginModule"
             : "com.sun.security.auth.module.Krb5LoginModule";
     }


### PR DESCRIPTION
IBM Semeru JDKs no longer ship their own com.ibm.security.* classes and instead ship the standard com.sun.security.* classes. This change checks for the presence of the IBM classes when an IBM JDK is detected and falls back to the standard classes if the IBM classes are not found.

There is currently a work in progress PR in hadoop (https://github.com/apache/hadoop/pull/4537) for the same issue and this PR uses the same approach.