### PR TITLE
[DIRKRB-761] The ticket lifetime obtained by the Kerberos client may be larger than the maximum set on the KDC

### DIFF
--- a/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/request/TicketIssuer.java
+++ b/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/request/TicketIssuer.java
@@ -169,8 +169,9 @@ public abstract class TicketIssuer {
         }
 
         KerberosTime krbEndTime = request.getReqBody().getTill();
-        if (krbEndTime == null || krbEndTime.getTime() == 0) {
-            krbEndTime = krbStartTime.extend(config.getMaximumTicketLifetime() * 1000);
+        KerberosTime maxEndTime = krbStartTime.extend(config.getMaximumTicketLifetime() * 1000);
+        if (krbEndTime == null || krbEndTime.getTime() == 0 || krbEndTime.greaterThan(maxEndTime)) {
+            krbEndTime = maxEndTime;
         } else if (krbStartTime.greaterThan(krbEndTime)) {
             throw new KrbException(KrbErrorCode.KDC_ERR_NEVER_VALID);
         }


### PR DESCRIPTION
[DIRKRB-761] Ensure that the lifetime of the ticket is not greater than the maximum lifetime set on the KDC