### PR TITLE
ENC_AUTHORIZATION_DATA type should be EncryptedData.class

### DIFF
--- a/kerby-kerb/kerb-core/src/main/java/org/apache/kerby/kerberos/kerb/type/kdc/KdcReqBody.java
+++ b/kerby-kerb/kerb-core/src/main/java/org/apache/kerby/kerberos/kerb/type/kdc/KdcReqBody.java
@@ -97,7 +97,7 @@ public class KdcReqBody extends KrbSequenceType {
             new ExplicitField(KdcReqBodyField.NONCE, Asn1Integer.class),
             new ExplicitField(KdcReqBodyField.ETYPE, KrbIntegers.class),
             new ExplicitField(KdcReqBodyField.ADDRESSES, HostAddresses.class),
-            new ExplicitField(KdcReqBodyField.ENC_AUTHORIZATION_DATA, AuthorizationData.class),
+            new ExplicitField(KdcReqBodyField.ENC_AUTHORIZATION_DATA, EncryptedData.class),
             new ExplicitField(KdcReqBodyField.ADDITIONAL_TICKETS, Tickets.class)
     };
 


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/html/rfc4120#section-5.4.1
Fixes issue getting TGS using Windows 11