### PR TITLE
Fixed a preauth validation issue

### DIFF
--- a/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/preauth/PreauthHandle.java
+++ b/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/preauth/PreauthHandle.java
@@ -42,8 +42,8 @@ public class PreauthHandle {
         preauth.provideEdata(kdcRequest, requestContext, outPaData);
     }
 
-    public void verify(KdcRequest kdcRequest, PaDataEntry paData) throws KrbException {
-        preauth.verify(kdcRequest, requestContext, paData);
+    public boolean verify(KdcRequest kdcRequest, PaDataEntry paData) throws KrbException {
+        return preauth.verify(kdcRequest, requestContext, paData);
     }
 
     public void providePaData(KdcRequest kdcRequest, PaData paData) {

--- a/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/preauth/PreauthHandler.java
+++ b/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/preauth/PreauthHandler.java
@@ -94,13 +94,14 @@ public class PreauthHandler {
         }
     }
 
-    public void verify(KdcRequest kdcRequest, PaData paData) throws KrbException {
+    public boolean verify(KdcRequest kdcRequest, PaData paData) throws KrbException {
         for (PaDataEntry paEntry : paData.getElements()) {
             PreauthHandle handle = findHandle(kdcRequest, paEntry.getPaDataType());
-            if (handle != null) {
-                handle.verify(kdcRequest, paEntry);
+            if (handle != null && handle.verify(kdcRequest, paEntry)) {
+                return true;
             }
         }
+        return false;
     }
 
     public void providePaData(KdcRequest kdcRequest, PaData paData) {

--- a/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/request/KdcRequest.java
+++ b/kerby-kerb/kerb-server/src/main/java/org/apache/kerby/kerberos/kerb/server/request/KdcRequest.java
@@ -678,18 +678,16 @@ public abstract class KdcRequest {
         }
 
         PaData preAuthData = request.getPaData();
-        if (preAuthData == null || preAuthData.isEmpty()) {
-            if (isPreauthRequired()) {
-                LOG.info("The preauth data is empty.");
-                KrbError krbError = makePreAuthenticationError(kdcContext, request,
-                        KrbErrorCode.KDC_ERR_PREAUTH_REQUIRED, false);
-                throw new KdcRecoverableException(krbError);
-            }
-        } else {
-            getPreauthHandler().verify(this, preAuthData);
+        if (preAuthData != null && !preAuthData.isEmpty()) {
+            boolean preAuthenticated = getPreauthHandler().verify(this, preAuthData);
+            setPreAuthenticated(preAuthenticated);
         }
-
-        setPreAuthenticated(true);
+        if (isPreauthRequired() && !isPreAuthenticated()) {
+            LOG.info("The preauth verification failed.");
+            KrbError krbError = makePreAuthenticationError(kdcContext, request,
+                    KrbErrorCode.KDC_ERR_PREAUTH_REQUIRED, false);
+            throw new KdcRecoverableException(krbError);
+        }
     }
 
     /**


### PR DESCRIPTION
If preauth is required, users can bypass it by sending an unknown preauth data entry. this is because we are only checking if preauth is present and not whether at least one preauth is valid