### PR TITLE
Simplify and explain the JWT functionality in Kerby

### DIFF
--- a/kerby-kerb/kerb-client/src/main/java/org/apache/kerby/kerberos/kerb/client/jaas/TokenAuthLoginModule.java
+++ b/kerby-kerb/kerb-client/src/main/java/org/apache/kerby/kerberos/kerb/client/jaas/TokenAuthLoginModule.java
@@ -25,7 +25,6 @@ import org.apache.kerby.kerberos.kerb.client.KrbClient;
 import org.apache.kerby.kerberos.kerb.client.KrbConfig;
 import org.apache.kerby.kerberos.kerb.client.KrbTokenClient;
 import org.apache.kerby.kerberos.kerb.common.PrivateKeyReader;
-import org.apache.kerby.kerberos.kerb.provider.TokenDecoder;
 import org.apache.kerby.kerberos.kerb.provider.TokenEncoder;
 import org.apache.kerby.kerberos.kerb.type.base.AuthToken;
 import org.apache.kerby.kerberos.kerb.type.base.KrbToken;
@@ -201,7 +200,7 @@ public class TokenAuthLoginModule implements LoginModule {
         LOG.info("\t\t[TokenAuthLoginModule]: Entering logout");
 
         if (subject.isReadOnly()) {
-            throw new LoginException("Subject is Readonly");
+            throwWith("Subject is Readonly");
         }
 
         for (Principal principal: subject.getPrincipals()) {
@@ -230,7 +229,7 @@ public class TokenAuthLoginModule implements LoginModule {
     private void validateConfiguration() throws LoginException {
 
         if (armorCache == null) {
-            throw new LoginException("An armor cache must be specified via the armorCache configuration option");
+            throwWith("An armor cache must be specified via the armorCache configuration option");
         }
 
         if (cCache == null) {
@@ -246,7 +245,7 @@ public class TokenAuthLoginModule implements LoginModule {
         }
 
         if (!error.isEmpty()) {
-            throw new LoginException(error);
+            throwWith(error);
         }
     }
 
@@ -254,7 +253,7 @@ public class TokenAuthLoginModule implements LoginModule {
         if (tokenStr == null) {
             tokenStr = TokenCache.readToken(tokenCacheName);
             if (tokenStr == null) {
-                throw new LoginException("No valid token was found in token cache: " + tokenCacheName);
+                throwWith("No valid token was found in token cache: " + tokenCacheName);
             }
         }
 
@@ -263,11 +262,13 @@ public class TokenAuthLoginModule implements LoginModule {
         // Sign the token.
         if (signKeyFile != null) {
             try {
-                TokenDecoder tokenDecoder = KrbRuntime.getTokenProvider("JWT").createTokenDecoder();
                 try {
-                    authToken = tokenDecoder.decodeFromString(tokenStr);
-                } catch (IOException e) {
-                    LOG.error("Token decode failed. " + e.toString());
+                    // Note no need to verify the token here since the KDC will verify it when we send it 
+                    // over. Just need to sign it and send it to KDC.
+                    JWT jwt = JWTParser.parse(tokenStr);
+                    authToken = new JwtAuthToken(jwt.getJWTClaimsSet());
+                } catch (ParseException e) {
+                    throw new RuntimeException("Failed to parse JWT token string", e);
                 }
                 TokenEncoder tokenEncoder = KrbRuntime.getTokenProvider("JWT").createTokenEncoder();
 
@@ -276,10 +277,20 @@ public class TokenAuthLoginModule implements LoginModule {
                     try (InputStream is = Files.newInputStream(signKeyFile.toPath())) {
                         signKey = PrivateKeyReader.loadPrivateKey(is);
                     } catch (IOException e) {
-                        LOG.error("Failed to load private key from file: "
-                                + signKeyFile.getName());
+                        throwWith("Failed to load private key from file: "
+                                + signKeyFile.getAbsolutePath(), e);
                     } catch (Exception e) {
-                        LOG.error(e.toString());
+                        throwWith("Failed to parse private key from file: "
+                                + signKeyFile.getAbsolutePath(), e);
+                    }
+
+                    if (signKey == null) {
+                        throwWith("Signing key file produced a null key: "
+                            + signKeyFile.getAbsolutePath());
+                    }
+                    if (!(signKey instanceof RSAPrivateKey)) {
+                        throwWith("Signing key is not an RSA private key: "
+                            + signKeyFile.getAbsolutePath());
                     }
 
                     ((JwtTokenEncoder) tokenEncoder).setSignKey((RSAPrivateKey) signKey);
@@ -372,5 +383,9 @@ public class TokenAuthLoginModule implements LoginModule {
         LoginException le = new LoginException(error);
         le.initCause(cause);
         throw le;
+    }
+
+    private void throwWith(String error) throws LoginException {
+        throw new LoginException(error);
     }
 }

--- a/kerby-kerb/kerb-core/src/main/java/org/apache/kerby/kerberos/kerb/provider/TokenDecoder.java
+++ b/kerby-kerb/kerb-core/src/main/java/org/apache/kerby/kerberos/kerb/provider/TokenDecoder.java
@@ -31,6 +31,13 @@ import java.security.PublicKey;
 public interface TokenDecoder {
 
     /**
+     * Configure whether only signed tokens are accepted.
+     *
+     * @param requireSignedTokens true to reject unsigned tokens
+     */
+    void setRequireSignedTokens(boolean requireSignedTokens);
+
+    /**
      * Decode a token from a bytes array.
      * @param content The content
      * @return token

--- a/kerby-kerb/kerb-core/src/main/java/org/apache/kerby/kerberos/kerb/type/base/KrbToken.java
+++ b/kerby-kerb/kerb-core/src/main/java/org/apache/kerby/kerberos/kerb/type/base/KrbToken.java
@@ -38,8 +38,8 @@ import org.apache.kerby.kerberos.kerb.provider.TokenEncoder;
  * }
  */
 public class KrbToken extends KrbTokenBase implements AuthToken {
-    private static TokenEncoder tokenEncoder;
-    private static TokenDecoder tokenDecoder;
+    private TokenEncoder tokenEncoder;
+    private TokenDecoder tokenDecoder;
 
     private AuthToken innerToken = null;
 
@@ -93,7 +93,14 @@ public class KrbToken extends KrbTokenBase implements AuthToken {
     public void decode(Asn1ParseResult parseResult) throws IOException {
         super.decode(parseResult);
         if (getTokenValue() != null) {
-            this.innerToken = getTokenDecoder(getTokenFormat()).decodeFromBytes(getTokenValue());
+            TokenDecoder decoder = getTokenDecoder(getTokenFormat());
+            // Allow unsigned JWTs here because this is not the original
+            // client-to-KDC token validation step. The KDC has already
+            // validated the external token and embedded its claims into the
+            // Kerberos ticket, whose integrity/authenticity is protected by
+            // Kerberos itself.
+            decoder.setRequireSignedTokens(false);
+            this.innerToken = decoder.decodeFromBytes(getTokenValue());
             setTokenType();
         }
     }
@@ -114,7 +121,7 @@ public class KrbToken extends KrbTokenBase implements AuthToken {
      * Get token encoder.
      * @return The token encoder
      */
-    protected static TokenEncoder getTokenEncoder(TokenFormat format) {
+    protected TokenEncoder getTokenEncoder(TokenFormat format) {
         if (tokenEncoder == null) {
             tokenEncoder = KrbRuntime.getTokenProvider(format.getName()).createTokenEncoder();
         }
@@ -125,7 +132,7 @@ public class KrbToken extends KrbTokenBase implements AuthToken {
      * Get token decoder.
      * @return The token decoder
      */
-    protected static TokenDecoder getTokenDecoder(TokenFormat format) {
+    protected TokenDecoder getTokenDecoder(TokenFormat format) {
         if (tokenDecoder == null) {
             tokenDecoder = KrbRuntime.getTokenProvider(format.getName()).createTokenDecoder();
         }

--- a/kerby-provider/token-provider/src/main/java/org/apache/kerby/kerberos/provider/token/JwtTokenDecoder.java
+++ b/kerby-provider/token-provider/src/main/java/org/apache/kerby/kerberos/provider/token/JwtTokenDecoder.java
@@ -56,6 +56,7 @@ public class JwtTokenDecoder implements TokenDecoder {
     private Object verifyKey;
     private List<String> audiences = null;
     private boolean signed = false;
+    private boolean requireSignedTokens = true;
 
     /**
      * {@inheritDoc}
@@ -72,7 +73,8 @@ public class JwtTokenDecoder implements TokenDecoder {
      */
     @Override
     public AuthToken decodeFromString(String content) throws IOException {
-       JWT jwt = null;
+        signed = false;
+        JWT jwt = null;
         try {
             jwt = JWTParser.parse(content);
         } catch (ParseException e) {
@@ -82,6 +84,9 @@ public class JwtTokenDecoder implements TokenDecoder {
 
         // Check the JWT type
         if (jwt instanceof PlainJWT) {
+            if (requireSignedTokens) {
+                return null;
+            }
             PlainJWT plainObject = (PlainJWT) jwt;
             try {
 
@@ -110,6 +115,9 @@ public class JwtTokenDecoder implements TokenDecoder {
                     return null;
                 }
             } else {
+                if (requireSignedTokens) {
+                    return null;
+                }
                 try {
                     if (verifyToken(encryptedJWT)) {
                         return new JwtAuthToken(encryptedJWT.getJWTClaimsSet());
@@ -290,4 +298,13 @@ public class JwtTokenDecoder implements TokenDecoder {
     public boolean isSigned() {
         return signed;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setRequireSignedTokens(boolean requireSignedTokens) {
+        this.requireSignedTokens = requireSignedTokens;
+    }
+
 }

--- a/kerby-provider/token-provider/src/test/java/org/apache/kerby/kerberos/provider/token/TokenTest.java
+++ b/kerby-provider/token-provider/src/test/java/org/apache/kerby/kerberos/provider/token/TokenTest.java
@@ -96,6 +96,14 @@ public class TokenTest {
         setAudience((JwtTokenDecoder) tokenDecoder, auds);
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
+        // Unsigned tokens are rejected by default
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
+        Assertions.assertThat(token2).isNull();
+
+        // Now allow unsigned tokens
+        tokenDecoder.setRequireSignedTokens(false);
+        token2 = tokenDecoder.decodeFromString(tokenStr);
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
         Assertions.assertThat(token2.getIssuer()).isEqualTo(ISSUER);
     }
@@ -112,6 +120,14 @@ public class TokenTest {
         setAudience((JwtTokenDecoder) tokenDecoder, auds);
 
         AuthToken token2 = tokenDecoder.decodeFromBytes(tokenStr);
+        // Unsigned tokens are rejected by default
+        Assertions.assertThat(token2).isNull();
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
+
+        // Now allow unsigned tokens
+        tokenDecoder.setRequireSignedTokens(false);
+        token2 = tokenDecoder.decodeFromBytes(tokenStr);
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
         Assertions.assertThat(token2.getIssuer()).isEqualTo(ISSUER);
     }
@@ -127,6 +143,9 @@ public class TokenTest {
 
         String tokenStr = tokenEncoder.encodeAsString(authToken);
         Assertions.assertThat(tokenStr).isNotNull();
+
+        // Now allow unsigned tokens
+        tokenDecoder.setRequireSignedTokens(false);
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
@@ -153,6 +172,9 @@ public class TokenTest {
 
         String tokenStr = tokenEncoder.encodeAsString(authToken);
         Assertions.assertThat(tokenStr).isNotNull();
+
+        // Now allow unsigned tokens
+        tokenDecoder.setRequireSignedTokens(false);
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
@@ -185,6 +207,7 @@ public class TokenTest {
         Assertions.assertThat(tokenStr).isNotNull();
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
+        Assertions.assertThat(tokenDecoder.isSigned()).isTrue();
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
         Assertions.assertThat(token2.getIssuer()).isEqualTo(ISSUER);
     }
@@ -208,6 +231,7 @@ public class TokenTest {
         Assertions.assertThat(tokenStr).isNotNull();
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
+        Assertions.assertThat(tokenDecoder.isSigned()).isTrue();
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
         Assertions.assertThat(token2.getIssuer()).isEqualTo(ISSUER);
 
@@ -215,8 +239,9 @@ public class TokenTest {
         secretKey = keyGenerator.generateKey().getEncoded();
         ((JwtTokenDecoder) tokenDecoder).setVerifyKey(secretKey);
 
-       token2 = tokenDecoder.decodeFromString(tokenStr);
-       Assertions.assertThat(token2).isNull();
+        token2 = tokenDecoder.decodeFromString(tokenStr);
+        Assertions.assertThat(token2).isNull();
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
     }
 
     @Test
@@ -257,6 +282,7 @@ public class TokenTest {
         Assertions.assertThat(tokenStr).isNotNull();
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
+        Assertions.assertThat(tokenDecoder.isSigned()).isTrue();
         Assertions.assertThat(token2.getSubject()).isEqualTo(SUBJECT);
         Assertions.assertThat(token2.getIssuer()).isEqualTo(ISSUER);
     }
@@ -279,6 +305,7 @@ public class TokenTest {
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
         Assertions.assertThat(token2).isNull();
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
     }
 
     @Test
@@ -298,6 +325,7 @@ public class TokenTest {
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
         Assertions.assertThat(token2).isNull();
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
     }
 
     @Test
@@ -317,6 +345,7 @@ public class TokenTest {
 
         AuthToken token2 = tokenDecoder.decodeFromString(tokenStr);
         Assertions.assertThat(token2).isNull();
+        Assertions.assertThat(tokenDecoder.isSigned()).isFalse();
     }
 
     private void setEncryptKey(JwtTokenEncoder encoder, JwtTokenDecoder decoder) throws NoSuchAlgorithmException {


### PR DESCRIPTION
- Parse rather than decode the JWT in TokenAuthLoginModule. We don't need to validate any signature here as we are just sending it to the KDC.
- Clarify in KrbToken that we don't need to enfore signed tokens, as we rely on integrity/authenticity is protected by Kerberos itself. 
- Switch JwtTokenDecoder to require signatures by default as a hardening mechanism.
- 